### PR TITLE
Remove duplicate code that adds publicKey to a DIDDocument

### DIFF
--- a/src/main/java/did/DIDDocument.java
+++ b/src/main/java/did/DIDDocument.java
@@ -96,22 +96,6 @@ public class DIDDocument {
 			jsonLdObject.put(JSONLD_TERM_PUBLICKEY, publicKeysJsonLdArray);
 		}
 
-		// add 'publicKey'
-
-		if (publicKeys != null) {
-
-			LinkedList<Object> publicKeysJsonLdArray = new LinkedList<Object> ();
-
-			for (PublicKey publicKey : publicKeys) {
-
-				Map<String, Object> publicKeyJsonLdObject = publicKey.getJsonLdObject();
-
-				publicKeysJsonLdArray.add(publicKeyJsonLdObject);
-			}
-
-			jsonLdObject.put(JSONLD_TERM_PUBLICKEY, publicKeysJsonLdArray);
-		}
-
 		// add 'service'
 
 		if (services != null) {


### PR DESCRIPTION
The `"publicKey"` array was being processed/added to `DIDDocument.jsonLdObject` twice, this PR removes the duplicate. The behaviour wasn't incorrect, just put the same thing twice.