### PR TITLE
Support Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>17</java.version>
+		<java.version>11</java.version>
 		<github.global.server>github</github.global.server>
 		<project.build.timestamp>${maven.build.timestamp}</project.build.timestamp>
 

--- a/src/main/java/foundation/identity/did/representations/consumption/RepresentationConsumer.java
+++ b/src/main/java/foundation/identity/did/representations/consumption/RepresentationConsumer.java
@@ -3,13 +3,52 @@ package foundation.identity.did.representations.consumption;
 import foundation.identity.did.representations.Representations;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public interface RepresentationConsumer {
 
-    public record Result(Map<String, Object> didDocument,
-                         Map<String, Map<String, Object>> representationSpecificEntries) {
+    public class Result {
+        private final Map<String, Object> didDocument;
+        private final Map<String, Map<String, Object>> representationSpecificEntries;
 
+        public Result(Map<String, Object> didDocument,
+            Map<String, Map<String, Object>> representationSpecificEntries) {
+            this.didDocument = Map.copyOf(didDocument);
+            Map<String, Map<String, Object>> tempMap = new HashMap<>();
+            representationSpecificEntries.forEach((key, value) ->
+                tempMap.put(key, Map.copyOf(value))
+            );
+            this.representationSpecificEntries = Collections.unmodifiableMap(tempMap);
+        }
+
+        public Map<String, Object> getDidDocument() {
+            return didDocument;
+        }
+
+        public Map<String, Map<String, Object>> getRepresentationSpecificEntries() {
+            return representationSpecificEntries;
+        }
+
+        // Implement equals and hashCode to mimic the behavior of a record
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Result result = (Result) o;
+
+            if (!didDocument.equals(result.didDocument)) return false;
+            return representationSpecificEntries.equals(result.representationSpecificEntries);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = didDocument.hashCode();
+            result = 31 * result + representationSpecificEntries.hashCode();
+            return result;
+        }
     }
 
     public static Result consume(byte[] representation, String mediaType) throws IOException {

--- a/src/main/java/foundation/identity/did/representations/production/RepresentationProducer.java
+++ b/src/main/java/foundation/identity/did/representations/production/RepresentationProducer.java
@@ -7,8 +7,43 @@ import java.util.Map;
 
 public interface RepresentationProducer {
 
-    public record Result(String mediaType, byte[] representation) {
+    public class Result {
+        private final String mediaType;
+        private final byte[] representation;
 
+        public Result(String mediaType, byte[] representation) {
+            this.mediaType = mediaType;
+            // It's important to clone the array to maintain immutability
+            this.representation = representation.clone();
+        }
+
+        public String getMediaType() {
+            return mediaType;
+        }
+
+        public byte[] getRepresentation() {
+            // Also clone the array on getter to prevent external modification
+            return representation.clone();
+        }
+
+        // Implement equals and hashCode to mimic the behavior of a record
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Result result = (Result) o;
+
+            if (!mediaType.equals(result.mediaType)) return false;
+            return java.util.Arrays.equals(representation, result.representation);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = mediaType.hashCode();
+            result = 31 * result + java.util.Arrays.hashCode(representation);
+            return result;
+        }
     }
 
     public static RepresentationProducer.Result produce(Map<String, Object> didDocument, Map<String, Object> representationSpecificEntries, String mediaType) throws IOException {

--- a/src/main/java/foundation/identity/did/representations/production/RepresentationProducerCBOR.java
+++ b/src/main/java/foundation/identity/did/representations/production/RepresentationProducerCBOR.java
@@ -26,7 +26,7 @@ public class RepresentationProducerCBOR extends AbstractRepresentationProducer i
     public RepresentationProducer.Result produce(Map<String, Object> didDocument, Map<String, Object> representationSpecificEntries) throws IOException {
 
         RepresentationProducer.Result jsonResult = RepresentationProducerJSON.getInstance().produce(didDocument, representationSpecificEntries);
-        CBORObject cborObject = CBORObject.FromJSONBytes(jsonResult.representation());
+        CBORObject cborObject = CBORObject.FromJSONBytes(jsonResult.getRepresentation());
         byte[] representation = cborObject.EncodeToBytes();
         return new RepresentationProducer.Result(MEDIA_TYPE, representation);
     }


### PR DESCRIPTION
we have some relatively large services that we can't yet update to Java 17. Instead of rolling our own library on parity with this one, it'd be great to use the work y'all have already done. 


This PR introduces support for Java 11. The only change that needed to be made was swapping out the use of `record` for java classes